### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/src/main/java/gov/osti/doecode/entity/SearchFunctions.java
+++ b/src/main/java/gov/osti/doecode/entity/SearchFunctions.java
@@ -1170,9 +1170,9 @@ public class SearchFunctions {
                 if (StringUtils.isNotBlank(JsonUtils.getString(biblio_data, "doi", ""))
                                 && StringUtils.isNotBlank(JsonUtils.getString(biblio_data, "release_date", ""))) {
                         String doi = JsonUtils.getString(biblio_data, "doi", "");
-                        optional_data.add(getOptionalBibtexObj("url", "{https://dx.doi.org/" + doi + "}"));
+                        optional_data.add(getOptionalBibtexObj("url", "{https://doi.org/" + doi + "}"));
                         optional_data.add(getOptionalBibtexObj("howpublished",
-                                        "{[Computer Software] \\url{https://dx.doi.org/" + doi + "}}"));
+                                        "{[Computer Software] \\url{https://doi.org/" + doi + "}}"));
                 }
 
                 // Release Date

--- a/src/main/resources/templates/search/biblio-sidebar.mustache
+++ b/src/main/resources/templates/search/biblio-sidebar.mustache
@@ -34,7 +34,7 @@
 						<span class="biblio-sidebar-secondary-subtitle">New {{#if biblio_sidebar.more_than_one_new}}Versions{{else}}Version{{/if}}</span>
 						<br />
 						{{#each biblio_sidebar.new_version}}
-							<a title='Previous Version #{{biblio_sidebar.code_id}}' href='https://dx.doi.org/{{.}}'>{{.}}</a>
+							<a title='Previous Version #{{biblio_sidebar.code_id}}' href='https://doi.org/{{.}}'>{{.}}</a>
 							<br />
 						{{/each}}
 					</div>
@@ -45,7 +45,7 @@
 						<span class="biblio-sidebar-secondary-subtitle">Previous {{#if biblio_sidebar.more_than_one_previous}}Versions{{else}}Version{{/if}}</span>
 						<br />
 						{{#each biblio_sidebar.prev_version}}
-							<a title='New Version #{{biblio_sidebar.code_id}}' href='https://dx.doi.org/{{.}}'>{{.}}</a>
+							<a title='New Version #{{biblio_sidebar.code_id}}' href='https://doi.org/{{.}}'>{{.}}</a>
 							<br />
 						{{/each}}
 					</div>


### PR DESCRIPTION
Follow up to #5. 

The DOI foundation recommends [the resolver without the `dx.` subdomain](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but the old links continue to work, so there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to any code that generates new DOI links.